### PR TITLE
시간 계산 로직 수정

### DIFF
--- a/server/src/main/java/org/server/core/metric/domain/ActiveTimeEntry.java
+++ b/server/src/main/java/org/server/core/metric/domain/ActiveTimeEntry.java
@@ -2,5 +2,10 @@ package org.server.core.metric.domain;
 
 import org.server.core.site.domain.SiteDomain;
 
-public record ActiveTimeEntry(SiteDomain siteDomain, long duration) {
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ActiveTimeEntry(SiteDomain siteDomain, List<PathDuration> pathDurations) {
+    public static record PathDuration(String path, Long duration, LocalDateTime lastRequestAt) {
+    }
 }


### PR DESCRIPTION
#1
#수정 사항
* 기존 도메인 기준으로 조회했던 시간을 path를 기준으로 계산하고 공통의 도메인을 가지는 path를 해당 도메인 하위에 모아서 반환하도록 수정